### PR TITLE
Add NVV to PickNetworkProviderActivity

### DIFF
--- a/src/de/grobox/liberario/PickNetworkProviderActivity.java
+++ b/src/de/grobox/liberario/PickNetworkProviderActivity.java
@@ -204,6 +204,7 @@ public class PickNetworkProviderActivity extends FragmentActivity {
 		de.add(new NetworkItem(NetworkId.NASA, "NASA", "Sachsen, Leipzig, Sachsen-Anhalt, Magdeburg, Halle", true));
 		de.add(new NetworkItem(NetworkId.VRR, "VRR", "Nordrhein-Westfalen, Köln, Bonn, Essen, Dortmund, Düsseldorf, Münster, Paderborn, Höxter"));
 		de.add(new NetworkItem(NetworkId.MVG, "MVG", "Märkischer Kreis, Lüdenscheid", true));
+		de.add(new NetworkItem(NetworkId.NVV, "NVV", "Hessen, Kassel"));
 		de.add(new NetworkItem(NetworkId.VRN, "VRN", "Baden-Württemberg, Rheinland-Pfalz, Mannheim, Mainz, Trier"));
 		de.add(new NetworkItem(NetworkId.VVS, "VVS", "Baden-Württemberg, Stuttgart"));
 		de.add(new NetworkItem(NetworkId.NALDO, "NALDO", "Reutlingen, Rottweil, Tübingen, Sigmaringen"));


### PR DESCRIPTION
This network was missing from the list of network providers, although it was in [pte since August 2011](https://code.google.com/p/public-transport-enabler/source/list?path=/enabler/src/de/schildbach/pte/NvvProvider.java&r=d2cd0b6603a344efd035cdff1591428c9ee8f54f).
I already tested it, by building Liberario myself and everything ran fine.
