### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest # to be able to run Android emulator, see https://github.com/marketplace/actions/android-emulator-runner
+    runs-on: macos-13 # to be able to run Android emulator, see https://github.com/marketplace/actions/android-emulator-runner
     
     strategy:
       fail-fast: false
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 17
       - name: Get AVD arch
         uses: ./.github/actions/get-avd-arch
         id: avd-arch


### PR DESCRIPTION
Had to update the java-version to fix this error in CI:
```
  Error: LinkageError occurred while loading main class com.android.sdklib.tool.sdkmanager.SdkManagerCli
  	java.lang.UnsupportedClassVersionError: com/android/sdklib/tool/sdkmanager/SdkManagerCli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```
This needed a macos version change, see here: https://github.com/ReactiveCircus/android-emulator-runner/issues/392#issuecomment-2106167725